### PR TITLE
Updated ros key

### DIFF
--- a/xenial-rosgl/scripts/ros_kinetic_setup.sh
+++ b/xenial-rosgl/scripts/ros_kinetic_setup.sh
@@ -26,13 +26,13 @@ if [ ! -e /etc/apt/sources.list.d/ros-latest.list ]; then
 fi
 
 echo "[Download the ROS keys]"
-roskey=`apt-key list | grep "ROS Builder"`
+roskey=`apt-key list | grep "Open Robotics"`
 if [ -z "$roskey" ]; then
-  apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
+  apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654 
 fi
 
 echo "[Check the ROS keys]"
-roskey=`apt-key list | grep "ROS Builder"`
+roskey=`apt-key list | grep "Open Robotics"`
 if [ -n "$roskey" ]; then
   echo "[ROS key exists in the list]"
 else


### PR DESCRIPTION
Hey!

The gpg keys for ros are outdated in the ros_kinetic_setup.sh script causing the script, and thus the docker image build, to fail.

I have updated the script and managed to build the docker image succesfully.

Context: [https://discourse.ros.org/t/new-gpg-keys-deployed-for-packages-ros-org/9454](https://discourse.ros.org/t/new-gpg-keys-deployed-for-packages-ros-org/9454)

Keep up the good work!

Cheers, 
Rui